### PR TITLE
WIP: TASK: Add package:// stream-wrapper that is relative to the package-path to make the autoinclusion from there cleaner

### DIFF
--- a/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
+++ b/Neos.Fusion/Classes/Core/ObjectTreeParser/FilePatternResolver.php
@@ -131,7 +131,7 @@ class FilePatternResolver
     {
         $files = [];
         foreach ($fileIterator as $fileInfo) {
-            if ($fileInfo->isDir()) {
+            if ($fileInfo->getFilename() === '..' || $fileInfo->isDir()) {
                 continue;
             }
             $pathAndFilename = $fileInfo->getPathname();

--- a/Neos.Neos/Classes/Domain/Service/FusionService.php
+++ b/Neos.Neos/Classes/Domain/Service/FusionService.php
@@ -57,25 +57,11 @@ class FusionService
     protected $siteRootFusionPattern = 'resource://%s/Private/Fusion/Root.fusion';
 
     /**
-     * Pattern used for determining the Fusion root file for a site
-     *
-     * @var string
-     */
-    protected $siteNodeTypesFolderPattern = 'resource://%s/../NodeTypes';
-
-    /**
      * Pattern used for determining the Fusion root file for autoIncludes
      *
      * @var string
      */
     protected $autoIncludeFusionPattern = 'resource://%s/Private/Fusion/Root.fusion';
-
-    /**
-     * Pattern used for determining the Fusion root file for autoIncludes
-     *
-     * @var string
-     */
-    protected $autoIncludeNodeTypesFolderPattern = 'resource://%s/../NodeTypes';
 
     /**
      * Array of Fusion files to include before the site Fusion
@@ -153,15 +139,14 @@ class FusionService
 
         $siteRootFusionPathAndFilename = sprintf($this->siteRootFusionPattern, $siteResourcesPackageKey);
         $siteRootFusionCode = $this->readExternalFusionFile($siteRootFusionPathAndFilename);
-        $siteNodeTypesFolder = sprintf($this->siteNodeTypesFolderPattern, $siteResourcesPackageKey);
 
         $mergedFusionCode = '';
         $mergedFusionCode .= $this->generateNodeTypeDefinitions();
         $mergedFusionCode .= $this->getFusionIncludes($this->prepareAutoIncludeFusion());
         $mergedFusionCode .= $this->getFusionIncludes($this->prependFusionIncludes);
         $mergedFusionCode .= $siteRootFusionCode;
-        if (is_dir($siteNodeTypesFolder)) {
-            $mergedFusionCode .= $this->getFusionIncludes([$siteNodeTypesFolder . '/**/*.fusion']);
+        if (is_dir('package://' . $siteResourcesPackageKey . '/NodeTypes')) {
+            $mergedFusionCode .= $this->getFusionIncludes(['package://' . $siteResourcesPackageKey . '/NodeTypes/' . '**/*.fusion']);
         }
         $mergedFusionCode .= $this->getFusionIncludes($this->appendFusionIncludes);
 
@@ -263,9 +248,8 @@ class FusionService
                 if (is_file($autoIncludeFusionFile)) {
                     $autoIncludeFusion[] = $autoIncludeFusionFile;
                 }
-                $autoIncludeNodeTypesFolder = sprintf($this->autoIncludeNodeTypesFolderPattern, $packageKey);
-                if (is_dir($autoIncludeNodeTypesFolder)) {
-                    $autoIncludeFusion[] = $autoIncludeNodeTypesFolder . '/**/*.fusion';
+                if (is_file('package://' . $packageKey . '/NodeTypes')) {
+                    $autoIncludeFusion[] = 'package://' . $packageKey . '/NodeTypes/**/*.fusion';
                 }
             }
         }


### PR DESCRIPTION
**Review instructions**

The actual package:// stream wrapper would be moved to flow before merging. I added this here to have all things in one place during development.

For now the stream wrapper is also a almost identical to the resource:// stream wrapper from flow minus the option to include resources via identifier and not allowing "/../" in pathes

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
